### PR TITLE
Stop when TargetYield is reached

### DIFF
--- a/CECA/CECA.cpp
+++ b/CECA/CECA.cpp
@@ -617,7 +617,7 @@ unsigned CECA::GoSingleCore(const unsigned& ThId){
     //printf("ExeTime = %u\n",ExeTime);
     DebugCounter++;
   }
-  while(ExeTime<Timeout);
+  while(ExeTime<Timeout && NumMultiplets * NumThreads <= TargetYield);
   if(DebugMode){
     //#pragma omp critical
     //{


### PR DESCRIPTION
For reproducibility, in case the target yield is a stronger constraint (e.g. testing and debugging) stop generating events when the target yield is reached. This avoids fluctuations on the time necessary to generate events and ensures deterministic output (at least if it is run on 1 thread only).